### PR TITLE
Add /slowmode command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const contactMods = require('./modules/contact-mods');
 const purgeMessages = require('./modules/purge-messages');
 const thread = require('./modules/thread');
 const logging = require('./modules/logging');
+const slowmode = require('./modules/slowmode');
 const bigBrother = tryRequire('./modules/big-brother');
 
 client.once(Events.ClientReady, (client) => {
@@ -97,6 +98,9 @@ client.on(Events.InteractionCreate, async (interaction) => {
                 break;
             case 'closethread':
                 await thread.close(interaction);
+                break;
+            case 'slowmode':
+                await slowmode.slowmode(interaction);
                 break;
             case 'Report User':
                 await contactMods.reportUser(interaction);

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
                 break;
             case 'slowmode':
                 await slowmode.slowmode(interaction);
+                break;
             case 'timeout':
                 await timeout.timeout(interaction);
                 break;

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -1,63 +1,99 @@
-const { MessageFlags, Permissions } = require('discord.js');
+const { PermissionsBitField } = require('discord.js');
 const config = require('../../config');
 
 const slowmode = async (interaction) => {
-  const slowmodeTime = interaction.options.getString('time');
-  const slowmodeReason = interaction.options.getString('reason');
   const modRole = await interaction.guild.roles.fetch(config.modRoleId);
-  let timeInSeconds = 0;
-  if(slowmodeTime.match(/t=[0-9]*h?[0-9]*m?[0-9]*s?/g).toString()==slowmodeTime){
-    slowmodeTime.replace(/([0-9]+)[h|m|s]/g, function(match, value) {
-      if (match.indexOf("h") > -1) {
-        timeInSeconds += value * 60 * 60;
-      } else if (match.indexOf("m") > -1) {
-        timeInSeconds += value * 60;
-      } else if (match.indexOf("s") > -1) {
-        timeInSeconds += value * 1;
-      };
-    });
-    await interaction.channel.setRateLimitPerUser(timeInSeconds, `Slowmode set by ${interaction.user.username} for reason: ` + (slowmodeReason ?? "No reason provided"));
-    if (timeInSeconds == 0) {
-      await interaction.reply(`⛅ Removed slowmode from this channel.`);
-    } else {
-      await interaction.reply(`🌨️ Set slowmode for this channel to **${slowmodeTime.replace(/\s+/g, '')}**.`);
-    }
-  } else if (slowmodeTime == "freeze") {
-    await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
-      SendMessages: false,
-      AttachFiles: false,
-      CreatePrivateThreads: false,
-      CreatePublicThreads: false
-    });
-    await interaction.channel.permissionOverwrites.edit(modRole.id, {
-      SendMessages: true,
-      AttachFiles: true,
-      CreatePrivateThreads: true,
-      CreatePublicThreads: true
-    });
-    await interaction.reply(`❄️ Froze the channel.`);
-  } else if (slowmodeTime == "unfreeze") {
-    await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
-      SendMessages: null,
-      AttachFiles: null,
-      CreatePrivateThreads: null,
-      CreatePublicThreads: null
-    });
-    await interaction.channel.permissionOverwrites.edit(modRole.id, {
-      SendMessages: null,
-      AttachFiles: null,
-      CreatePrivateThreads: null,
-      CreatePublicThreads: null
-    });
-    await interaction.reply(`☀️ Unfroze the channel.`);
-  } else if (slowmodeTime == "") {
-    await interaction.channel.setRateLimitPerUser(0, `Slowmode set by ${interaction.user.username} for reason: ` + (slowmodeReason ?? "No reason provided"));
-    await interaction.reply(`⛅ Removed slowmode from this channel.`);
+  const slowmodeEnabled = interaction.options.getBoolean('state');
+  let slowmodeTime = interaction.options.getString('time');
+  const slowmodeReason = interaction.options.getString('reason');
+
+  if (slowmodeTime === null) {
+    slowmodeTime = 30;
   }
-  
-  
+
+  const currentRateLimit = interaction.channel.rateLimitPerUser;
+
+  if (slowmodeEnabled) {
+    if (slowmodeTime === 'freeze') {
+      await interaction.channel.permissionOverwrites.edit(
+        interaction.guild.roles.everyone,
+        {
+          [PermissionsBitField.Flags.SendMessages]: false,
+          [PermissionsBitField.Flags.ManageMessages]: false,
+          [PermissionsBitField.Flags.CreatePublicThreads]: false,
+          [PermissionsBitField.Flags.CreatePrivateThreads]: false,
+        }
+      );
+
+      await interaction.channel.permissionOverwrites.edit(modRole, {
+        [PermissionsBitField.Flags.SendMessages]: true,
+        [PermissionsBitField.Flags.ManageMessages]: true,
+        [PermissionsBitField.Flags.CreatePublicThreads]: true,
+        [PermissionsBitField.Flags.CreatePrivateThreads]: true,
+      });
+
+      return await interaction.reply(
+        `❄️ Channel has been frozen. Only moderators can send messages or create threads.`
+      );
+    }
+
+    slowmodeTime = parseInt(slowmodeTime);
+
+    if (currentRateLimit > 0) {
+      if (currentRateLimit === slowmodeTime) {
+        return await interaction.reply(
+          `⏳ Slowmode is already set to **${slowmodeTime} second(s)**.`
+        );
+      }
+      await interaction.channel.setRateLimitPerUser(
+        slowmodeTime,
+        `Slowmode updated by ${interaction.user.username} for reason: ` +
+          (slowmodeReason ?? 'No reason provided')
+      );
+      return await interaction.reply(
+        `🌨️ Slowmode updated to **${slowmodeTime} second(s)**.`
+      );
+    }
+
+    await interaction.channel.setRateLimitPerUser(
+      slowmodeTime,
+      `Slowmode set by ${interaction.user.username} for reason: ` +
+        (slowmodeReason ?? 'No reason provided')
+    );
+    return await interaction.reply(
+      `🌨️ Slowmode enabled for **${slowmodeTime} second(s)**.`
+    );
+  }
+
+  if (!slowmodeEnabled) {
+    await interaction.channel.permissionOverwrites.edit(
+      interaction.guild.roles.everyone,
+      {
+        [PermissionsBitField.Flags.SendMessages]: null,
+        [PermissionsBitField.Flags.ManageMessages]: null,
+        [PermissionsBitField.Flags.CreatePublicThreads]: null,
+        [PermissionsBitField.Flags.CreatePrivateThreads]: null,
+      }
+    );
+
+    await interaction.channel.permissionOverwrites.edit(modRole, {
+      [PermissionsBitField.Flags.SendMessages]: null,
+      [PermissionsBitField.Flags.ManageMessages]: null,
+      [PermissionsBitField.Flags.CreatePublicThreads]: null,
+      [PermissionsBitField.Flags.CreatePrivateThreads]: null,
+    });
+
+    await interaction.channel.setRateLimitPerUser(
+      0,
+      `Slowmode and freeze disabled by ${interaction.user.username} for reason: ` +
+        (slowmodeReason ?? 'No reason provided')
+    );
+    return await interaction.reply(
+      `⛅ Slowmode and freeze have been disabled in this channel.`
+    );
+  }
 };
 
 module.exports = {
-  slowmode
+  slowmode,
 };

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -20,7 +20,7 @@ const slowmode = async (interaction) => {
     if (timeInSeconds == 0) {
       await interaction.reply(`⛅ Removed slowmode from this channel.`);
     } else {
-      await interaction.reply(`🌨️ Set slowmode for this channel to **${slowmodeTime.replace(/\s+/g, '');}**.`);
+      await interaction.reply(`🌨️ Set slowmode for this channel to **${slowmodeTime.replace(/\s+/g, '')}**.`);
     }
   } else if (slowmodeTime == "freeze") {
     await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -1,0 +1,58 @@
+const { MessageFlags, Permissions } = require('discord.js');
+
+const slowmode = async (interaction) => {
+  const slowmodeTime = interaction.options.getString('time');
+  const slowmodeReason = interaction.options.getString('reason');
+  const modRole = await interaction.guild.roles.fetch(config.modRoleId);
+  let timeInSeconds = 0;
+  if(slowmodeTime.match(/t=[0-9]*h?[0-9]*m?[0-9]*s?/g).toString()==slowmodeTime){
+    slowmodeTime.replace(/([0-9]+)[h|m|s]/g, function(match, value) {
+      if (match.indexOf("h") > -1) {
+        timeInSeconds += value * 60 * 60;
+      } else if (match.indexOf("m") > -1) {
+        timeInSeconds += value * 60;
+      } else if (match.indexOf("s") > -1) {
+        timeInSeconds += value * 1;
+      };
+    });
+    await interaction.channel.setRateLimitPerUser(timeInSeconds, `Slowmode set by ${interaction.user.username} for reason: ` + (slowmodeReason ?? "No reason provided"));
+    if (timeInSeconds == 0) {
+      await interaction.reply(`⛅ Removed slowmode from this channel.`);
+    } else {
+      await interaction.reply(`🌨️ Set slowmode for this channel to **${slowmodeTime.replace(/\s+/g, '');}**.`);
+    }
+  } else if (slowmodeTime == "freeze") {
+    await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
+      SendMessages: false,
+      AttachFiles: false,
+      CreatePrivateThreads: false
+    });
+    await interaction.channel.permissionOverwrites.edit(modRole.id, {
+      SendMessages: true,
+      AttachFiles: true,
+      CreatePrivateThreads: true
+    });
+    await interaction.reply(`❄️ Froze the channel.`);
+  } else if (slowmodeTime == "unfreeze") {
+    await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
+      SendMessages: null,
+      AttachFiles: null,
+      CreatePrivateThreads: null
+    });
+    await interaction.channel.permissionOverwrites.edit(modRole.id, {
+      SendMessages: null,
+      AttachFiles: null,
+      CreatePrivateThreads: null
+    });
+    await interaction.reply(`☀️ Unfroze the channel.`);
+  } else if (slowmodeTime == "") {
+    await interaction.channel.setRateLimitPerUser(0, `Slowmode set by ${interaction.user.username} for reason: ` + (slowmodeReason ?? "No reason provided"));
+    await interaction.reply(`⛅ Removed slowmode from this channel.`);
+  }
+  
+  
+};
+
+module.exports = {
+  slowmode
+};

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -26,24 +26,28 @@ const slowmode = async (interaction) => {
     await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
       SendMessages: false,
       AttachFiles: false,
-      CreatePrivateThreads: false
+      CreatePrivateThreads: false,
+      CreatePublicThreads: false
     });
     await interaction.channel.permissionOverwrites.edit(modRole.id, {
       SendMessages: true,
       AttachFiles: true,
-      CreatePrivateThreads: true
+      CreatePrivateThreads: true,
+      CreatePublicThreads: true
     });
     await interaction.reply(`❄️ Froze the channel.`);
   } else if (slowmodeTime == "unfreeze") {
     await interaction.channel.permissionOverwrites.edit(message.guild.roles.everyone.id, {
       SendMessages: null,
       AttachFiles: null,
-      CreatePrivateThreads: null
+      CreatePrivateThreads: null,
+      CreatePublicThreads: null
     });
     await interaction.channel.permissionOverwrites.edit(modRole.id, {
       SendMessages: null,
       AttachFiles: null,
-      CreatePrivateThreads: null
+      CreatePrivateThreads: null,
+      CreatePublicThreads: null
     });
     await interaction.reply(`☀️ Unfroze the channel.`);
   } else if (slowmodeTime == "") {

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -19,7 +19,6 @@ const slowmode = async (interaction) => {
         interaction.guild.roles.everyone,
         {
           [PermissionsBitField.Flags.SendMessages]: false,
-          [PermissionsBitField.Flags.ManageMessages]: false,
           [PermissionsBitField.Flags.CreatePublicThreads]: false,
           [PermissionsBitField.Flags.CreatePrivateThreads]: false,
         }
@@ -27,7 +26,6 @@ const slowmode = async (interaction) => {
 
       await interaction.channel.permissionOverwrites.edit(modRole, {
         [PermissionsBitField.Flags.SendMessages]: true,
-        [PermissionsBitField.Flags.ManageMessages]: true,
         [PermissionsBitField.Flags.CreatePublicThreads]: true,
         [PermissionsBitField.Flags.CreatePrivateThreads]: true,
       });
@@ -70,7 +68,6 @@ const slowmode = async (interaction) => {
       interaction.guild.roles.everyone,
       {
         [PermissionsBitField.Flags.SendMessages]: null,
-        [PermissionsBitField.Flags.ManageMessages]: null,
         [PermissionsBitField.Flags.CreatePublicThreads]: null,
         [PermissionsBitField.Flags.CreatePrivateThreads]: null,
       }
@@ -78,7 +75,6 @@ const slowmode = async (interaction) => {
 
     await interaction.channel.permissionOverwrites.edit(modRole, {
       [PermissionsBitField.Flags.SendMessages]: null,
-      [PermissionsBitField.Flags.ManageMessages]: null,
       [PermissionsBitField.Flags.CreatePublicThreads]: null,
       [PermissionsBitField.Flags.CreatePrivateThreads]: null,
     });

--- a/src/modules/slowmode.js
+++ b/src/modules/slowmode.js
@@ -1,4 +1,5 @@
 const { MessageFlags, Permissions } = require('discord.js');
+const config = require('../../config');
 
 const slowmode = async (interaction) => {
   const slowmodeTime = interaction.options.getString('time');

--- a/src/modules/star-board.js
+++ b/src/modules/star-board.js
@@ -79,7 +79,7 @@ const stringifyMessageContent = (message) => {
         }
     }
 
-    return message.messageSnapshots.first().content ? `-# *↱ Forwarded message:*\n${message.messageSnapshots.first().content}` : message.content;
+    return message.messageSnapshots.first() ? `-# *↱ Forwarded message:*\n${message.messageSnapshots.first().content}` : message.content;
 };
 
 /**

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -52,7 +52,8 @@ const commands = [
             .setName('reason')
             .setDescription('Reason why slowmode is being applied.')
             .setMaxLength(1000)
-        ),
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
     new ContextMenuCommandBuilder()
         .setName('Report User')
         .setType(ApplicationCommandType.User),

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -45,8 +45,13 @@ const commands = [
         .setDescription('Set slowmode in a channel, or freeze it')
         .addStringOption(option => option
             .setName('time')
-            .setDescription('Amount of time s/m/h to set slowmode to, or "freeze" to freeze. ')
+            .setDescription('Amount of time s/m/h to set slowmode to, or "freeze" to freeze.')
             .setMaxLength(10)
+        )
+        .addStringOption(option => option
+            .setName('reason')
+            .setDescription('Reason why slowmode is being applied.')
+            .setMaxLength(1000)
         ),
     new ContextMenuCommandBuilder()
         .setName('Report User')

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -40,6 +40,14 @@ const commands = [
         .setName('closethread')
         .setDescription('Locks and closes a thread')
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageThreads),
+    new SlashCommandBuilder()
+        .setName('slowmode')
+        .setDescription('Set slowmode in a channel, or freeze it')
+        .addStringOption(option => option
+            .setName('time')
+            .setDescription('Amount of time s/m/h to set slowmode to, or "freeze" to freeze. ')
+            .setMaxLength(10)
+        ),
     new ContextMenuCommandBuilder()
         .setName('Report User')
         .setType(ApplicationCommandType.User),

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -45,7 +45,7 @@ const commands = [
         .setDescription('Set slowmode in a channel, or freeze it')
         .addStringOption(option => option
             .setName('time')
-            .setDescription('Amount of time s/m/h to set slowmode to, or "freeze" to freeze.')
+            .setDescription('Amount of time in h/m/s to set slowmode to, or "freeze"/"unfreeze".')
             .setMaxLength(10)
         )
         .addStringOption(option => option

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -65,7 +65,7 @@ const commands = [
                 { name: '1 hour', value: '3600' },
                 { name: '2 hours', value: '7200' },
                 { name: '6 hours', value: '21600' },
-                { name: 'freeze', value: 'freeze'}
+                { name: 'freeze', value: 'freeze' }
             )
         )
         .addStringOption(option => option

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -42,15 +42,35 @@ const commands = [
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageThreads),
     new SlashCommandBuilder()
         .setName('slowmode')
-        .setDescription('Set slowmode in a channel, or freeze it')
+        .setDescription('Set slowmode in the current channel')
+        .addBooleanOption(option => option
+            .setName('state')
+            .setDescription('Whether or not slowmode is enabled')
+            .setRequired(true)
+        )
         .addStringOption(option => option
             .setName('time')
-            .setDescription('Amount of time in h/m/s to set slowmode to, or "freeze"/"unfreeze".')
-            .setMaxLength(10)
+            .setDescription('Amount of time slowmode is set to')
+            .addChoices(
+                { name: '5 seconds', value: '5' },
+                { name: '10 seconds', value: '10' },
+                { name: '15 seconds', value: '15' },
+                { name: '30 seconds', value: '30' },
+                { name: '1 minute', value: '60' },
+                { name: '2 minutes', value: '120' },
+                { name: '5 minutes', value: '300' },
+                { name: '10 minutes', value: '600' },
+                { name: '15 minutes', value: '900' },
+                { name: '30 minutes', value: '1800' },
+                { name: '1 hour', value: '3600' },
+                { name: '2 hours', value: '7200' },
+                { name: '6 hours', value: '21600' },
+                { name: 'freeze', value: 'freeze'}
+            )
         )
         .addStringOption(option => option
             .setName('reason')
-            .setDescription('Reason why slowmode is being applied.')
+            .setDescription('Reason why slowmode is being applied')
             .setMaxLength(1000)
         )
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),


### PR DESCRIPTION
Allows using `/slowmode` in channels

Given a defined set of options from the menu, but by default, it'll be 30 seconds. Freezing is also an option, and people with the mod role are exempted.

@GarboMuffin, you're going to need to reregister the commands once this is merged.

- Should freezing be a separate command? It would make some things in `/slowmode` simpler.