### PR TITLE
Add /timeout command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const contactMods = require('./modules/contact-mods');
 const purgeMessages = require('./modules/purge-messages');
 const thread = require('./modules/thread');
 const logging = require('./modules/logging');
+const timeout = require('./modules/timeout');
 const bigBrother = tryRequire('./modules/big-brother');
 
 client.once(Events.ClientReady, (client) => {
@@ -97,6 +98,9 @@ client.on(Events.InteractionCreate, async (interaction) => {
                 break;
             case 'closethread':
                 await thread.close(interaction);
+                break;
+            case 'timeout':
+                await timeout.timeout(interaction);
                 break;
             case 'Report User':
                 await contactMods.reportUser(interaction);

--- a/src/modules/timeout.js
+++ b/src/modules/timeout.js
@@ -1,0 +1,25 @@
+const { MessageFlags } = require('discord.js');
+
+const timeout = async (interaction) => {
+  const user = interaction.options.getUser('user');
+  const member = interaction.options.getMember('user');
+  const amount = interaction.options.getInteger('time') ?? 60;
+  const reason = interaction.options.getReason('reason') ?? "No reason provided";
+
+  try {
+    await member.timeout(amount*60000, reason);
+    await user.send({
+      content: `⏲️ You have been timed out in the Turbowarp server for the following reason: ${reason}`,
+      flags: MessageFlags.SuppressNotifications
+    });
+  } catch (error) {
+    await interaction.reply({
+      content: 'Failed to timeout user.',
+      flags: MessageFlags.Ephemeral
+    });
+  }
+};
+
+module.exports = {
+  timeout
+};

--- a/src/modules/timeout.js
+++ b/src/modules/timeout.js
@@ -1,4 +1,4 @@
-const { MessageFlags } = require('discord.js');
+const { MessageFlags, PermissionsBitField } = require('discord.js');
 
 const timeout = async (interaction) => {
   const user = interaction.options.getUser('user');
@@ -7,11 +7,22 @@ const timeout = async (interaction) => {
   const reason = interaction.options.getReason('reason') ?? "No reason provided";
 
   try {
-    await member.timeout(amount*60000, reason);
-    await user.send({
-      content: `⏲️ You have been timed out in the Turbowarp server for the following reason: ${reason}`,
-      flags: MessageFlags.SuppressNotifications
-    });
+    if (member.permissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+      await member.timeout(amount*60000, reason);
+      await user.send({
+        content: `⏲️ You have been timed out in the Turbowarp server for the following reason: ${reason}`,
+        flags: MessageFlags.SuppressNotifications
+      });
+      await interaction.reply({
+        content: `⏲️ Successfully timed out <@${user.id}> for ${amount} minutes with reason: ${reason}`,
+        flags: MessageFlags.Ephemeral
+      })
+    } else {
+      await interaction.reply({
+        content: `Failed to timeout user: You can't timeout moderators!`,
+        flags: MessageFlags.Ephemeral
+      })
+    }
   } catch (error) {
     await interaction.reply({
       content: 'Failed to timeout user.',

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -28,6 +28,40 @@ const commands = [
             .setRequired(true)
         ),
     new SlashCommandBuilder()
+        .setName('timeout')
+        .setDescription('Timeout a user')
+        .addUserOption(option => option
+            .setName('user')
+            .setDescription('The user to timeout')
+            .setRequired(true)
+        )
+        .addIntegerOption(option => option
+            .setName('time')
+            .setDescription('Amount of time the user is timed out for, in hours')
+            .addChoices(
+                { name: '1 minute', value: 1 },
+                { name: '3 minutes', value: 3 },
+                { name: '5 minutes', value: 5 },
+                { name: '10 minutes', value: 10 },
+                { name: '30 minutes', value: 30 },
+                { name: '1 hour', value: 60 },
+                { name: '6 hours', value: 360 },
+                { name: '12 hours', value: 720 },
+                { name: '1 day', value: 1440 },
+                { name: '2 days', value: 2880 },
+                { name: '3 days', value: 4320 },
+                { name: '1 week', value: 10080 },
+                { name: '2 weeks', value: 20160 },
+                { name: '4 weeks', value: 40320 }
+            )
+        )
+        .addStringOption(option => option
+            .setName('reason')
+            .setDescription('Reason why timeout is being applied')
+            .setMaxLength(1000)
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+    new SlashCommandBuilder()
         .setName('purge')
         .setDescription('Purge messages in the current channel')
         .addIntegerOption(option => option


### PR DESCRIPTION
Introducing the `/timeout` command, the special blinged-out version of the normal built-in `/timeout`! This allows for timeout durations ranging from just a minute to 4 weeks! Additionally, the reason provided in the command is DMed to the timed-out user, so there is no confusion if the punishment comes in late (previously, because the user couldn't open a ticket, they have to DM a moderator, which is unprofessional.)

Users who have moderator permissions cannot be timed out by this command, and only moderators can see or use it. 