### PR TITLE
Reintroduce /pingmods command alongside /contactmods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const tryRequire = (path) => {
 
 const starBoard = require('./modules/star-board');
 const contactMods = require('./modules/contact-mods');
+const pingMods = require('./modules/ping-mods');
 const purgeMessages = require('./modules/purge-messages');
 const thread = require('./modules/thread');
 const logging = require('./modules/logging');
@@ -91,6 +92,9 @@ client.on(Events.InteractionCreate, async (interaction) => {
         switch (interaction.commandName) {
             case 'contactmods':
                 await contactMods.contactMods(interaction);
+                break;
+            case 'pingmods':
+                await pingMods.pingMods(interaction);
                 break;
             case 'purge':
                 await purgeMessages.purgeMessages(interaction);

--- a/src/modules/ping-mods.js
+++ b/src/modules/ping-mods.js
@@ -1,0 +1,32 @@
+const client = require('../client');
+const config = require('../../config');
+
+const pingMods = async (interaction) => {
+    const reason = interaction.options.getString('reason');
+    const recentMessages = await interaction.channel.messages.fetch({
+        limit: 1
+    });
+    const mostRecentMessage = recentMessages.first();
+    const modRole = await interaction.guild.roles.fetch(config.modRoleId);
+    const modChannel = await client.channels.fetch(config.modChannelId);
+
+    let pingMessage = `${modRole}: ${interaction.user} pinged mods in ${interaction.channel}`;
+    if (mostRecentMessage) {
+        pingMessage += ` at ${mostRecentMessage.url}`;
+    }
+    if (reason) {
+        pingMessage += ' because:\n\`\`\`';
+        pingMessage += reason.replace(/```/g, '[escaped code block]');
+        pingMessage += '\n\`\`\`';
+    }
+    await modChannel.send(pingMessage);
+
+    await interaction.reply({
+        content: 'Mods have been pinged. Be patient. Pinging again does not help.',
+        ephemeral: true
+    });
+};
+
+module.exports = {
+    pingMods
+};

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -14,7 +14,7 @@ const {
 const commands = [
     new SlashCommandBuilder()
         .setName('contactmods')
-        .setDescription('Contact moderators without posting a public message (previously /pingmods)')
+        .setDescription('Contact moderators without posting a public message')
         .addStringOption(option => option
             .setName('topic')
             .setDescription('What are you contacting us about?')
@@ -26,6 +26,14 @@ const commands = [
             .setDescription('Give us information on why you are contacting us.')
             .setMaxLength(1000)
             .setRequired(true)
+        ),
+    new SlashCommandBuilder()
+        .setName('pingmods')
+        .setDescription('Ping moderators without posting a public message')
+        .addStringOption(option => option
+            .setName('reason')
+            .setDescription('Message will be provided to moderators.')
+            .setMaxLength(1000)
         ),
     new SlashCommandBuilder()
         .setName('purge')


### PR DESCRIPTION
Users can now contact moderators more quickly in busy chats, and not have to hang around in a ticket for an issue that's simple and doesn't need to be explained.