### PR TITLE
Neve show [No Content] detection messages in logging

### DIFF
--- a/src/modules/logging.js
+++ b/src/modules/logging.js
@@ -31,6 +31,7 @@ const editedMessage = async (oldMessage, newMessage) => {
   let log = {
     allowedMentions: { parse: [] }
   };
+  let nocontent = false
   if (oldMessage.pinned !== newMessage.pinned) {
     log.content = `📌 [Message](${newMessage.url}) by <@${newMessage.author.id}> was ${newMessage.pinned ? '' : 'un'}pinned in ${newMessage.channel.url}`;
   } else if (oldMessage.flags.has('SuppressEmbeds') !== newMessage.flags.has('SuppressEmbeds')) {
@@ -45,7 +46,11 @@ const editedMessage = async (oldMessage, newMessage) => {
       }));
     }
     if (diff.length <= 250) {
-      log.content += `\n\`\`\`${diff ? `diff\n${diff}` : '\n[No Content]'}\n\`\`\``;
+      if (diff) {
+        log.content += `\n\`\`\`diff\n${diff}\n\`\`\``;
+      } else {
+        nocontent = true
+      }
     } else {
       log.files = log.files.concat([
         new AttachmentBuilder(
@@ -55,8 +60,9 @@ const editedMessage = async (oldMessage, newMessage) => {
       ]);
     }
   }
-
-  await logChannel.send(log);
+  if (!nocontent) {
+    await logChannel.send(log);
+  }
 };
 
 const deletedMessage = async (message) => {


### PR DESCRIPTION
Don't make the message if there's No Content. There is no situation that exists where you can legitimately edit a message to have No Content, because if it starts with no content, you can only add some, and if it starts with content and you remove it, Discord prompts the user to delete it instead. This will greatly clear up wayback machine and stop it from being so clogged with meaningless spam messages. This is kind of a silly way to solve the problem, but ultimately it serves the same purpose.